### PR TITLE
Feature/predefined oauth domain

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,2 +1,3 @@
 PREACT_APP_API_URL=http://localhost:3001
 PREACT_APP_CLIENT_ID=182832041414-bqv4iaaso8q2oo342i71ftf5uugi3cs7.apps.googleusercontent.com
+PREACT_APP_OAUTH_DOMAIN=elpassion.pl

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -34,6 +34,7 @@ export default class App extends Component {
       gapi.auth2.init({ // eslint-disable-line no-undef
         client_id: process.env.PREACT_APP_CLIENT_ID,
         cookiepolicy: 'single_host_origin',
+        hosted_domain: process.env.PREACT_APP_OAUTH_DOMAIN,
       });
     });
   }


### PR DESCRIPTION
Add predefined domain for google oauth to login with simple username not whole email address (user will be forced to use predefined domain).